### PR TITLE
Add Helm Chart

### DIFF
--- a/charts/bacula-exporter/.helmignore
+++ b/charts/bacula-exporter/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/bacula-exporter/Chart.yaml
+++ b/charts/bacula-exporter/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+appVersion: "1.0.1"
+description: Helm chart bacula_exporter for Kubernetes
+name: bacula-exporter
+version: 1.0.0
+home: https://github.com/funbox/bacula_exporter
+maintainers:
+  - name: Gleb Goncharov
+    email: g.goncharov@fun-box.ru

--- a/charts/bacula-exporter/templates/NOTES.txt
+++ b/charts/bacula-exporter/templates/NOTES.txt
@@ -1,0 +1,5 @@
+1.To see the metrics
+{{- if contains "ClusterIP" .Values.service.type }}
+  kubectl port-forward svc/{{ include "bacula-exporter.fullname" . }} {{ .Values.service.port }}
+  echo "Visit http://127.0.0.1:{{ .Values.service.port }} to use your application"
+{{- end }}

--- a/charts/bacula-exporter/templates/_helpers.tpl
+++ b/charts/bacula-exporter/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bacula-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bacula-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bacula-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/bacula-exporter/templates/deployment.yaml
+++ b/charts/bacula-exporter/templates/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bacula-exporter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "bacula-exporter.name" . }}
+    helm.sh/chart: {{ include "bacula-exporter.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.labels -}}
+    {{ .Values.labels | toYaml | nindent 4 -}}
+    {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "bacula-exporter.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "bacula-exporter.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .Values.podLabels -}}
+        {{ .Values.podLabels | toYaml | nindent 8 -}}
+        {{- end }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: 33407
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 1
+            httpGet:
+              path: /health
+              port: metrics
+              scheme: HTTP
+            initialDelaySeconds: 3
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 9
+          readinessProbe:
+            failureThreshold: 1
+            httpGet:
+              path: /health
+              port: metrics
+              scheme: HTTP
+            initialDelaySeconds: 3
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 9
+          volumeMounts:
+            - name: {{ include "bacula-exporter.fullname" . }}
+              mountPath: /config/bacula_exporter.knf
+              readOnly: true
+              subPath: bacula_exporter.knf
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: {{ include "bacula-exporter.fullname" . }}
+          secret:
+            secretName: {{ include "bacula-exporter.fullname" . }}
+            defaultMode: 0400
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/bacula-exporter/templates/secret.yaml
+++ b/charts/bacula-exporter/templates/secret.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "bacula-exporter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "bacula-exporter.name" . }}
+    helm.sh/chart: {{ include "bacula-exporter.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.labels -}}
+    {{- .Values.labels | toYaml | nindent 4 }}
+    {{- end }}
+type: Opaque
+stringData:
+  bacula_exporter.knf: |
+    [http]
+      ip: {{ .Values.baculaExporter.http.ip }}
+      port: {{ .Values.baculaExporter.http.port }}
+      endpoint: {{ .Values.baculaExporter.http.endpoint }}
+
+    [db]
+      name: {{ .Values.baculaExporter.db.name }}
+      username: {{ .Values.baculaExporter.db.username }}
+      password: {{ .Values.baculaExporter.db.password }}
+      host: {{ .Values.baculaExporter.db.host }}
+      port: {{ .Values.baculaExporter.db.port }}
+      sslmode: {{ .Values.baculaExporter.db.sslmode }}
+
+    [log]
+      output: {{ .Values.baculaExporter.log.output }}
+      dir: {{ .Values.baculaExporter.log.dir }}
+      file: {log:dir}/bacula_exporter.log
+      perms: {{ .Values.baculaExporter.log.perms }}
+      level: {{ .Values.baculaExporter.log.level }}

--- a/charts/bacula-exporter/templates/service.yaml
+++ b/charts/bacula-exporter/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bacula-exporter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "bacula-exporter.name" . }}
+    helm.sh/chart: {{ include "bacula-exporter.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.labels -}}
+    {{ .Values.labels | toYaml | nindent 4 -}}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    app.kubernetes.io/name: {{ include "bacula-exporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/bacula-exporter/templates/servicemonitor.yaml
+++ b/charts/bacula-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.prometheus.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "bacula-exporter.fullname" . }}
+  {{- if .Values.prometheus.serviceMonitor.namespace }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "bacula-exporter.name" . }}
+    helm.sh/chart: {{ include "bacula-exporter.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.labels -}}
+    {{ .Values.labels | toYaml | nindent 4 -}}
+    {{- end }}
+    {{- if .Values.prometheus.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.prometheus.serviceMonitor.additionalLabels | indent 4 -}}
+    {{- end }}
+spec:
+  jobLabel: jobLabel
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "bacula-exporter.name" . }}
+      helm.sh/chart: {{ include "bacula-exporter.chart" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  - port: metrics
+    interval: {{ .Values.prometheus.serviceMonitor.interval }}
+    {{- if .Values.prometheus.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.prometheus.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    {{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .Values.prometheus.serviceMonitor.metricRelabelings | nindent 4 }}
+  {{- end }}
+  {{- end }}

--- a/charts/bacula-exporter/values.yaml
+++ b/charts/bacula-exporter/values.yaml
@@ -1,0 +1,68 @@
+# Default values for bacula-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: funbox/bacula_exporter
+  tag: 1.0.1
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 33407
+
+baculaExporter:
+  http:
+    ip: 0.0.0.0
+    port: 33407
+    endpoint: /metrics
+  
+  db:
+    name: bacula
+    username: bacula
+    password: keepinsecret
+    host: db.example.tld
+    port: 5432
+    sslmode: disable
+  
+  log:
+    output: console
+    dir: /
+    file: \{log:dir\}/bacula_exporter.log
+    perms: 600
+    level: info
+
+prometheus:
+  serviceMonitor:
+    enabled: true
+    namespace: monitoring
+    interval: "30s"
+    additionalLabels:
+      app: bacula-exporter
+    metricRelabelings: {}
+
+labels: {}
+podLabels: {}
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
I propose to review the following changes into the codebase to support Helm Chart installation to Kubernetes. This PR provides ready to go YAML manifests and templates which are intended to get used with Prometheus/VictoriaMetrics Operator respectively using ServiceMonitor CRD (Custom Resource Definition).